### PR TITLE
Support profiles from alias files

### DIFF
--- a/home-module.nix
+++ b/home-module.nix
@@ -62,12 +62,13 @@ in
       example = literalExpression ''
         {
           default = {
-            GITHUB_TOKEN = "Social/github";
-            AWS_ACCESS_KEY = "Work/aws/access_key";
+            GITHUB_TOKEN = "Social/github/token";
+            NPM_AUTH_TOKEN = "Development/npm/auth_token";
           };
           work = {
+            AWS_ACCESS_KEY_ID = "Work/aws/access_key_id";
+            AWS_SECRET_ACCESS_KEY = "Work/aws/secret_key";
             JIRA_API_TOKEN = "Work/jira/api_token";
-            SLACK_TOKEN = "Work/slack/token";
           };
         }
       '';

--- a/home-module.nix
+++ b/home-module.nix
@@ -10,6 +10,22 @@ with lib;
 
 let
   cfg = config.programs.pass-profile;
+
+  # Function to write profile files
+  writeProfileFile =
+    name: vars:
+    pkgs.writeTextFile {
+      name = name;
+      text = concatStringsSep "\n" (mapAttrsToList (envVar: passPath: "${envVar}:${passPath}") vars);
+      destination = "/share/pass-profile/profile/${name}";
+    };
+
+  # Create a package that contains all the profile files
+  profilePackage = pkgs.symlinkJoin {
+    name = "pass-profile-profiles";
+    paths = mapAttrsToList writeProfileFile cfg.profile;
+  };
+
   pass-profile = ''
     pass-profile() {
       local profile=''${1:-default}
@@ -39,10 +55,40 @@ in
       default = config.programs.bash.enable;
       description = "Whether to enable pass-profile integration with Bash.";
     };
+
+    profile = mkOption {
+      type = types.attrsOf (types.attrsOf types.str);
+      default = { };
+      example = literalExpression ''
+        {
+          default = {
+            GITHUB_TOKEN = "Social/github";
+            AWS_ACCESS_KEY = "Work/aws/access_key";
+          };
+          work = {
+            JIRA_API_TOKEN = "Work/jira/api_token";
+            SLACK_TOKEN = "Work/slack/token";
+          };
+        }
+      '';
+      description = ''
+        An attribute set of profiles, where each profile is an attribute set
+        mapping environment variable names to pass paths.
+
+        These will be written to ~/.pass-profile/profile/ and can be used
+        alongside profiles stored in the password store.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
+
+    # Link the profile files from the profile package
+    home.file = mkIf (cfg.profile != { }) {
+      "pass-profile/profile".source = "${profilePackage}/share/pass-profile/profile";
+      "pass-profile/profile".target = ".pass-profile/profile";
+    };
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration pass-profile;
     programs.bash.initExtra = mkIf cfg.enableBashIntegration pass-profile;

--- a/pass_profile/main.py
+++ b/pass_profile/main.py
@@ -2,6 +2,7 @@ import argparse
 import subprocess
 import sys
 import os
+import pathlib
 
 
 def get_pass_entries(profile_name):
@@ -12,60 +13,135 @@ def get_pass_entries(profile_name):
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
         # Parse the output to get entry names
-        entries = []
-        result_list = result.stdout.strip().split('\n')
+        entries = {}
+        result_list = result.stdout.strip().split("\n")
         if len(result_list) > 1:
             result_list = result_list[1:]
 
         for line in result_list:
             # Skip the first line which is the directory name and empty lines
-            if line and not line.endswith('/'):
+            if line and not line.endswith("/"):
                 # Extract just the env var name (last part of the path)
-                entry = line.strip().strip('└──').strip('├──').strip()
-                if '/' in entry:
-                    entry = entry.split('/')[-1]
+                entry = line.strip().strip("└──").strip("├──").strip()
+                if "/" in entry:
+                    entry = entry.split("/")[-1]
                 if entry:
-                    entries.append(entry)
+                    # Add to dictionary with env_var_name as key (uppercased) and pass_path as value
+                    entries[entry.upper()] = f"Profile/{profile_name}/{entry}"
 
         return entries
     except subprocess.CalledProcessError as e:
+        # Check if this is just a "not in password store" error
+        if "is not in the password store" in e.stderr:
+            return None
+        # For other errors, exit with error
         print(f"Error accessing pass: {e}", file=sys.stderr)
         print(f"stderr: {e.stderr}", file=sys.stderr)
         sys.exit(1)
 
 
-def get_env_value(profile_name, env_var):
-    """Get the value of an environment variable from pass."""
+def get_file_entries(profile_name):
+    """Get all entries from a .pass-profile/profile/{profile_name} file."""
+    entries = {}
+    profile_path = pathlib.Path.home() / ".pass-profile" / "profile" / profile_name
+
+    if not profile_path.exists():
+        return None
+
     try:
-        cmd = ["pass", f"Profile/{profile_name}/{env_var}"]
+        with open(profile_path, "r") as f:
+            for line in f:
+                line = line.strip()
+                # Skip empty lines and comments
+                if not line or line.startswith("#"):
+                    continue
+
+                # Check if it's in the format name:password
+                if ":" in line:
+                    env_var, pass_path = line.split(":", 1)
+                    entries[env_var.strip()] = pass_path.strip()
+                else:
+                    # It's just a password path, extract the last part as env var name
+                    pass_path = line
+                    env_var = pass_path.split("/")[-1].upper()
+                    entries[env_var] = pass_path
+        return entries
+    except Exception as e:
+        print(f"Error reading profile file {profile_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def get_env_value(pass_path):
+    """Get the value of an environment variable from pass.
+
+    pass_path is the path to the password in the pass store
+    """
+    try:
+        cmd = ["pass", pass_path]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
         return result.stdout.strip()
     except subprocess.CalledProcessError as e:
-        print(f"Error retrieving {env_var}: {e}", file=sys.stderr)
-        return None
+        print(f"Error retrieving {pass_path}: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Generate environment variables from pass profiles.')
-    parser.add_argument('profile_name', nargs='?', default='default',
-                        help='Name of the profile in pass (stored under Profile/). Defaults to "default"')
+    parser = argparse.ArgumentParser(
+        description="Generate environment variables from pass profiles."
+    )
+    parser.add_argument(
+        "profile_name",
+        nargs="?",
+        default="default",
+        help='Name of the profile in pass (stored under Profile/) or in .pass-profile/profile/. Defaults to "default"',
+    )
 
     args = parser.parse_args()
 
-    # Get all environment variables stored in the profile
-    env_vars = get_pass_entries(args.profile_name)
+    # Get environment variables from both sources
+    pass_entries = get_pass_entries(args.profile_name)
+    file_entries = get_file_entries(args.profile_name)
 
-    if not env_vars:
-        print(f"No environment variables found for profile '{args.profile_name}'", file=sys.stderr)
+    # Check if both sources are None (profile doesn't exist in either place)
+    if pass_entries is None and file_entries is None:
+        print(
+            f"Profile '{args.profile_name}' not found in pass store or in .pass-profile/profile/",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
+    # Initialize env_vars_dict from pass entries
+    env_vars_dict = {}
+    if pass_entries is not None:
+        env_vars_dict.update(pass_entries)
+
+    # Add file entries if they exist, overriding any duplicates
+    if file_entries is not None:
+        # Check for duplicates before updating
+        for env_var_name in file_entries:
+            if env_var_name in env_vars_dict:
+                print(
+                    f"Warning: Entry '{env_var_name}' exists in both pass and file profile. Using file version.",
+                    file=sys.stderr,
+                )
+
+        # Update with file entries
+        env_vars_dict.update(file_entries)
+
+    if not env_vars_dict:
+        print(
+            f"Warning: No environment variables found for profile '{args.profile_name}'",
+            file=sys.stderr,
+        )
+        # Not exiting with error, just warning
+
     # Generate shell commands to set environment variables
-    for env_var in env_vars:
-        value = get_env_value(args.profile_name, env_var)
+    for env_var_name, pass_path in env_vars_dict.items():
+        value = get_env_value(pass_path)
         if value:
             # Escape special characters in the value
             escaped_value = value.replace('"', '\\"')
-            print(f'export {env_var}="{escaped_value}"')
+            print(f'export {env_var_name}="{escaped_value}"')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces a new way to specify profiles. You can now put a file under `~/.pass-profile/profile/<profile_name>`, and it'll be used as an alias file.

This lets you compose profiles from different passwords, regardless of hierarchy in the password store. That way, if some pass entry is needed in multiple profiles, it doesn't have to be redefined in the password store several times, but can just be aliased.

This also updates the home-manager module to allow generation of these alias files.