### PR TITLE
fix: change zsh.initExtra to zsh.initContent in home-module.nix

### DIFF
--- a/home-module.nix
+++ b/home-module.nix
@@ -91,7 +91,7 @@ in
       "pass-profile/profile".target = ".pass-profile/profile";
     };
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration pass-profile;
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration pass-profile;
     programs.bash.initExtra = mkIf cfg.enableBashIntegration pass-profile;
   };
 }


### PR DESCRIPTION
in home-manager, zsh.initExtra got deprecated in favor of zsh.initContent. This PR changes to the new option.